### PR TITLE
Fix errors listed in terminal

### DIFF
--- a/src/components/Review.js
+++ b/src/components/Review.js
@@ -24,7 +24,7 @@ function Review(props) {
                                 ? <img
                                     src={pic}
                                     className='movie-result-image'
-                                    atl={'Image for ' + movie.display_title}
+                                    alt={'Image for ' + movie.display_title}
                                 />
                                 : <div className='movie-result-image no-image'><p>No Image</p></div>
                         }
@@ -36,7 +36,7 @@ function Review(props) {
                         </div>
                         <ul>
                             <li><p>Critic:</p> {movie.byline !== '' ? movie.byline : 'N/A'}</li>
-                            <li><p>Review Summary:</p> {movie.summary_short != '' ? movie.summary_short : 'N/A'}</li>
+                            <li><p>Review Summary:</p> {movie.summary_short !== '' ? movie.summary_short : 'N/A'}</li>
                             <li><p>Rating:</p> {movie.mpaa_rating !== '' ? movie.mpaa_rating : 'N/A'}</li>
                             <li><p>Release Date:</p> {movie.opening_date !== null ? movie.opening_date : 'N/A'}</li>
                         </ul>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -8,8 +8,8 @@ var _APIKEY = '&api-key=lDScKB3aIURGUXjTzj5U8RAZtaSF8n1F'
 
 function getMovie(movie) {
     return axios.get(_baseURL + movie + _APIKEY )
-        .then(function (movie) {
-            return movie.data
+        .then(function (res) {
+            return res.data
         })
         .catch(function (error) {
             console.error(error)


### PR DESCRIPTION
Resolved these errors presented in the terminal after running npm start
Line 24:  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/alt-text
Line 39:  Expected '!==' and instead saw '!=' 